### PR TITLE
Throw Exception in Request::getItemId instead of returning false

### DIFF
--- a/src/Controller/ApplicationsController.php
+++ b/src/Controller/ApplicationsController.php
@@ -158,10 +158,6 @@ class ApplicationsController extends BaseApiController
 
         $clientId = $this->getItemId($request);
 
-        if (false === $clientId) {
-            throw new Exception('Invalid client ID', Http::NOT_FOUND);
-        }
-
         $client = $clientMapper->getClientByIdAndUser(
             $clientId,
             $request->user_id

--- a/src/Controller/ApplicationsController.php
+++ b/src/Controller/ApplicationsController.php
@@ -19,7 +19,7 @@ class ApplicationsController extends BaseApiController
         $mapper = $this->getClientMapper($db, $request);
 
         $client = $mapper->getClientByIdAndUser(
-            (string) $this->getItemId($request),
+            (string) $this->getItemId($request, 'Invalid client ID'),
             $request->user_id
         );
 
@@ -137,7 +137,7 @@ class ApplicationsController extends BaseApiController
         $app['user_id'] = $request->user_id;
 
         $clientMapper = $this->getClientMapper($db, $request);
-        $clientId     = $clientMapper->updateClient((string) $this->getItemId($request), $app);
+        $clientId     = $clientMapper->updateClient((string) $this->getItemId($request, 'Invalid client ID'), $app);
 
         $uri = $request->base . '/' . $request->version . '/applications/' . $clientId;
         $request->getView()->setResponseCode(Http::CREATED);
@@ -156,7 +156,7 @@ class ApplicationsController extends BaseApiController
 
         $clientMapper = $this->getClientMapper($db, $request);
 
-        $clientId = $this->getItemId($request);
+        $clientId = $this->getItemId($request, 'Invalid client ID');
 
         $client = $clientMapper->getClientByIdAndUser(
             $clientId,

--- a/src/Controller/BaseApiController.php
+++ b/src/Controller/BaseApiController.php
@@ -2,7 +2,9 @@
 
 namespace Joindin\Api\Controller;
 
+use Exception;
 use Joindin\Api\Request;
+use Teapot\StatusCode\Http;
 
 abstract class BaseApiController
 {
@@ -10,7 +12,7 @@ abstract class BaseApiController
     {
     }
 
-    public function getItemId(Request $request): false|int
+    public function getItemId(Request $request): int
     {
         // item ID
         if (
@@ -20,7 +22,7 @@ abstract class BaseApiController
             return (int) $request->url_elements[3];
         }
 
-        return false;
+        throw new Exception('Item not found', Http::NOT_FOUND);
     }
 
     public function getVerbosity(Request $request): bool

--- a/src/Controller/BaseApiController.php
+++ b/src/Controller/BaseApiController.php
@@ -12,7 +12,7 @@ abstract class BaseApiController
     {
     }
 
-    public function getItemId(Request $request): int
+    public function getItemId(Request $request, ?string $errorMessage = null): int
     {
         // item ID
         if (
@@ -22,7 +22,7 @@ abstract class BaseApiController
             return (int) $request->url_elements[3];
         }
 
-        throw new Exception('Item not found', Http::NOT_FOUND);
+        throw new Exception($errorMessage ?? 'Item not found', Http::NOT_FOUND);
     }
 
     public function getVerbosity(Request $request): bool

--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -113,7 +113,7 @@ class BaseTalkController extends BaseApiController
         $mapper = $this->getTalkMapper($db, $request);
 
         if (0 === $talk_id) {
-            $talk_id = $this->getItemId($request);
+            $talk_id = $this->getItemId($request, 'Talk not found');
         }
 
         $talk = $mapper->getTalkById($talk_id, $verbose);

--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -116,10 +116,6 @@ class BaseTalkController extends BaseApiController
             $talk_id = $this->getItemId($request);
         }
 
-        if (false === $talk_id) {
-            throw new Exception('Talk not found', Http::NOT_FOUND);
-        }
-
         $talk = $mapper->getTalkById($talk_id, $verbose);
 
         if (false === $talk) {

--- a/src/Controller/EventCommentsController.php
+++ b/src/Controller/EventCommentsController.php
@@ -26,9 +26,9 @@ class EventCommentsController extends BaseApiController
         $this->spamCheckService = $spamCheckService;
     }
 
-    public function getComments(Request $request, PDO $db): false|array
+    public function getComments(Request $request, PDO $db): array
     {
-        $comment_id = $this->getItemId($request);
+        $comment_id = $this->getItemId($request, 'Comment not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -39,22 +39,18 @@ class EventCommentsController extends BaseApiController
 
         $mapper = new EventCommentMapper($db, $request);
 
-        if ($comment_id) {
-            $list = $mapper->getCommentById($comment_id, $verbose);
+        $list = $mapper->getCommentById($comment_id, $verbose);
 
-            if (false === $list) {
-                throw new Exception('Comment not found', Http::NOT_FOUND);
-            }
-
-            return $list;
+        if (false === $list) {
+            throw new Exception('Comment not found', Http::NOT_FOUND);
         }
 
-        return false;
+        return $list;
     }
 
     public function getReported(Request $request, PDO $db): array
     {
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -78,7 +74,7 @@ class EventCommentsController extends BaseApiController
     public function createComment(Request $request, PDO $db): void
     {
         $comment             = [];
-        $comment['event_id'] = $this->getItemId($request);
+        $comment['event_id'] = $this->getItemId($request, 'Event not found');
 
         if (empty($comment['event_id'])) {
             throw new Exception(
@@ -179,7 +175,7 @@ class EventCommentsController extends BaseApiController
 
         $comment_mapper = new EventCommentMapper($db, $request);
 
-        $commentId   = $this->getItemId($request);
+        $commentId   = $this->getItemId($request, 'Comment not found');
 
         if (false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))) {
             throw new Exception('Comment not found', Http::NOT_FOUND);
@@ -236,7 +232,7 @@ class EventCommentsController extends BaseApiController
         }
 
         $comment_mapper = new EventCommentMapper($db, $request);
-        $commentId   = $this->getItemId($request);
+        $commentId   = $this->getItemId($request, 'Comment not found');
 
         if (false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))) {
             throw new Exception('Comment not found', Http::NOT_FOUND);

--- a/src/Controller/EventCommentsController.php
+++ b/src/Controller/EventCommentsController.php
@@ -56,10 +56,6 @@ class EventCommentsController extends BaseApiController
     {
         $event_id = $this->getItemId($request);
 
-        if (empty($event_id)) {
-            throw new UnexpectedValueException("Event not found", Http::NOT_FOUND);
-        }
-
         // verbosity
         $verbose = $this->getVerbosity($request);
 
@@ -185,10 +181,7 @@ class EventCommentsController extends BaseApiController
 
         $commentId   = $this->getItemId($request);
 
-        if (
-            false === $commentId
-            || false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))
-        ) {
+        if (false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))) {
             throw new Exception('Comment not found', Http::NOT_FOUND);
         }
 
@@ -245,10 +238,7 @@ class EventCommentsController extends BaseApiController
         $comment_mapper = new EventCommentMapper($db, $request);
         $commentId   = $this->getItemId($request);
 
-        if (
-            false === $commentId
-            || false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))
-        ) {
+        if (false === ($commentInfo = $comment_mapper->getCommentInfo($commentId))) {
             throw new Exception('Comment not found', Http::NOT_FOUND);
         }
 

--- a/src/Controller/EventHostsController.php
+++ b/src/Controller/EventHostsController.php
@@ -28,7 +28,7 @@ class EventHostsController extends BaseApiController
      */
     public function listHosts(Request $request, PDO $db): array
     {
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -67,7 +67,7 @@ class EventHostsController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         $eventMapper = $this->getEventMapper($request, $db);
         $event       = $eventMapper->getEventById($event_id);
@@ -130,7 +130,7 @@ class EventHostsController extends BaseApiController
         }
 
         $user_id = $request->url_elements[5];
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         if ($user_id === $request->user_id) {
             throw new Exception('You are not allowed to remove yourself from the host-list', Http::FORBIDDEN);

--- a/src/Controller/EventImagesController.php
+++ b/src/Controller/EventImagesController.php
@@ -29,11 +29,6 @@ class EventImagesController extends BaseApiController
         }
 
         $event_id = $this->getItemId($request);
-
-        if (false === $event_id) {
-            throw new Exception("Invalid event ID", Http::BAD_REQUEST);
-        }
-
         $event_mapper = new EventMapper($db, $request);
 
         // ensure event exists
@@ -142,9 +137,6 @@ class EventImagesController extends BaseApiController
 
         $event_id     = $this->getItemId($request);
 
-        if (false === $event_id) {
-            throw new Exception("Invalid event ID", Http::BAD_REQUEST);
-        }
         $event_mapper = new EventMapper($db, $request);
         $event_mapper->removeImages($event_id);
 

--- a/src/Controller/EventImagesController.php
+++ b/src/Controller/EventImagesController.php
@@ -15,11 +15,11 @@ class EventImagesController extends BaseApiController
      */
     public function listImages(Request $request, PDO $db): array
     {
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         $event_mapper = new EventMapper($db, $request);
 
-        return ['images' => $event_mapper->getImages((int) $event_id)];
+        return ['images' => $event_mapper->getImages($event_id)];
     }
 
     public function createImage(Request $request, PDO $db): void
@@ -28,7 +28,7 @@ class EventImagesController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
         $event_mapper = new EventMapper($db, $request);
 
         // ensure event exists
@@ -135,7 +135,7 @@ class EventImagesController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id     = $this->getItemId($request, 'Event not found');
 
         $event_mapper = new EventMapper($db, $request);
         $event_mapper->removeImages($event_id);

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -35,7 +35,7 @@ class EventsController extends BaseApiController
 
     public function getAction(Request $request, PDO $db): array|false
     {
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -200,7 +200,7 @@ class EventsController extends BaseApiController
                 case 'attending':
                     // the body of this request is completely irrelevant
                     // The logged in user *is* attending the event.  Use DELETE to unattend
-                    $event_id     = $this->getItemId($request);
+                    $event_id     = $this->getItemId($request, 'Event not found');
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserAttendance($event_id, $request->user_id);
 
@@ -432,7 +432,7 @@ class EventsController extends BaseApiController
         if (isset($request->url_elements[4])) {
             switch ($request->url_elements[4]) {
                 case 'attending':
-                    $event_id     = $this->getItemId($request);
+                    $event_id     = $this->getItemId($request, 'Event not found');
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserNonAttendance($event_id, $request->user_id);
 
@@ -460,7 +460,7 @@ class EventsController extends BaseApiController
             throw new Exception('You must be logged in to edit data', Http::UNAUTHORIZED);
         }
 
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         if (!isset($request->url_elements[4])) {
             // Edit an Event
@@ -623,7 +623,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to view pending claims", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id     = $this->getItemId($request, 'Event not found');
         $event_mapper = $this->getEventMapper($db, $request);
 
         $pending_talk_claim_mapper = $this->getPendingTalkClaimMapper($db, $request);
@@ -659,7 +659,7 @@ class EventsController extends BaseApiController
         }
 
         $track             = [];
-        $event_id          = $this->getItemId($request);
+        $event_id          = $this->getItemId($request, 'Event not found');
         $track['event_id'] = $event_id;
 
         if (empty($track['event_id'])) {
@@ -731,7 +731,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id     = $this->getItemId($request, 'Event not found');
         $event_mapper = new EventMapper($db, $request);
 
         if (!$event_mapper->thisUserCanApproveEvents()) {
@@ -772,7 +772,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id     = $this->getItemId($request, 'Event not found');
         $event_mapper = new EventMapper($db, $request);
         $reason = htmlspecialchars($request->getStringParameter('reason'));
 

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -12,7 +12,7 @@ class LanguagesController extends BaseApiController
 {
     public function getLanguage(Request $request, PDO $db): false|array
     {
-        $language_id = $this->getItemId($request);
+        $language_id = $this->getItemId($request, 'Language not found');
         // verbosity - here for consistency as we don't have verbose language details to return at the moment
         $verbose = $this->getVerbosity($request);
 

--- a/src/Controller/TalkCommentsController.php
+++ b/src/Controller/TalkCommentsController.php
@@ -46,10 +46,6 @@ class TalkCommentsController extends BaseApiController
     {
         $eventId = $this->getItemId($request);
 
-        if (empty($eventId)) {
-            throw new UnexpectedValueException("Event not found", Http::NOT_FOUND);
-        }
-
         $eventMapper   = new EventMapper($db, $request);
         $commentMapper = $this->getCommentMapper($request, $db);
 

--- a/src/Controller/TalkCommentsController.php
+++ b/src/Controller/TalkCommentsController.php
@@ -22,7 +22,7 @@ class TalkCommentsController extends BaseApiController
 
     public function getComments(Request $request, PDO $db): false|array
     {
-        $commentId = $this->getItemId($request);
+        $commentId = $this->getItemId($request, 'Comment not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -44,7 +44,7 @@ class TalkCommentsController extends BaseApiController
 
     public function getReported(Request $request, PDO $db): array
     {
-        $eventId = $this->getItemId($request);
+        $eventId = $this->getItemId($request, 'Event not found');
 
         $eventMapper   = new EventMapper($db, $request);
         $commentMapper = $this->getCommentMapper($request, $db);
@@ -71,7 +71,7 @@ class TalkCommentsController extends BaseApiController
 
         $commentMapper = $this->getCommentMapper($request, $db);
 
-        $commentId   = $this->getItemId($request);
+        $commentId   = $this->getItemId($request, 'Comment not found');
         $commentInfo = $commentMapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
@@ -123,7 +123,7 @@ class TalkCommentsController extends BaseApiController
 
         $commentMapper = $this->getCommentMapper($request, $db);
 
-        $commentId   = $this->getItemId($request);
+        $commentId   = $this->getItemId($request, 'Comment not found');
         $commentInfo = $commentMapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
@@ -166,7 +166,7 @@ class TalkCommentsController extends BaseApiController
             throw new Exception('The field "comment" is required', Http::BAD_REQUEST);
         }
 
-        $commentId     = $this->getItemId($request);
+        $commentId     = $this->getItemId($request, 'Comment not found');
         $commentMapper = $this->getCommentMapper($request, $db);
         $comment       = $commentMapper->getRawComment($commentId);
 

--- a/src/Controller/TalkTypesController.php
+++ b/src/Controller/TalkTypesController.php
@@ -26,7 +26,7 @@ class TalkTypesController extends BaseApiController
 
     public function getTalkType(Request $request, PDO $db): false|array
     {
-        $talk_type_id = $this->getItemId($request);
+        $talk_type_id = $this->getItemId($request, 'Talk type not found');
         // verbosity - here for consistency as we don't have verbose talk type details to return at the moment
         $verbose = $this->getVerbosity($request);
 

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -42,7 +42,7 @@ class TalksController extends BaseTalkController
     public function getAction(Request $request, PDO $db): array
     {
         $this->setDbAndRequest($db, $request);
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
 
         $verbose = $this->getVerbosity($request);
 
@@ -55,7 +55,7 @@ class TalksController extends BaseTalkController
     public function getTalkComments(Request $request, PDO $db): false|array
     {
         $this->setDbAndRequest($db, $request);
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
         $verbose = $this->getVerbosity($this->request);
 
         // pagination settings
@@ -71,7 +71,7 @@ class TalksController extends BaseTalkController
     public function getTalkStarred(Request $request, PDO $db): array
     {
         $this->setDbAndRequest($db, $request);
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
 
         /** @var TalkMapper $mapper */
         $mapper  = $this->getMapper('talk');
@@ -107,7 +107,7 @@ class TalksController extends BaseTalkController
     public function postAction(Request $request, PDO $db): void
     {
         $this->checkLoggedIn($request);
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
 
         // Retrieve the talk. It if doesn't exist, then 404 with talk not found
         $talk = $this->getTalkById($request, $db, $talk_id);
@@ -222,7 +222,7 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk_id     = $this->getItemId($request);
+        $talk_id     = $this->getItemId($request, 'Talk not found');
         $talk_mapper = $this->getTalkMapper($db, $request);
         $talk_mapper->setUserNonStarred($talk_id, $request->user_id);
 
@@ -235,7 +235,7 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk_id     = $this->getItemId($request);
+        $talk_id     = $this->getItemId($request, 'Talk not found');
         $talk_mapper = $this->getTalkMapper($db, $request);
 
         $talk = $talk_mapper->getTalkById($talk_id);
@@ -383,7 +383,7 @@ class TalksController extends BaseTalkController
     public function createTalkAction(Request $request, PDO $db): array
     {
         $this->checkLoggedIn($request);
-        $event_id = $this->getItemId($request);
+        $event_id = $this->getItemId($request, 'Event not found');
 
         if (empty($event_id)) {
             throw new Exception(
@@ -444,7 +444,7 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
 
         $talk_mapper = new TalkMapper($db, $request);
 
@@ -586,7 +586,7 @@ class TalksController extends BaseTalkController
 
     public function getSpeakersForTalk(Request $request, PDO $db): array
     {
-        $talk_id = $this->getItemId($request);
+        $talk_id = $this->getItemId($request, 'Talk not found');
         $talk    = $this->getTalkById($request, $db, $talk_id);
 
         return $talk->speakers;
@@ -740,7 +740,7 @@ class TalksController extends BaseTalkController
     public function removeApprovedSpeakerFromTalk(Request $request, PDO $db): void
     {
         $this->checkLoggedIn($request);
-        $talk_id    = $this->getItemId($request);
+        $talk_id    = $this->getItemId($request, 'Talk not found');
         $speaker_id = $request->url_elements[5];
 
         $talk_mapper = new TalkMapper($db, $request);

--- a/src/Controller/TokenController.php
+++ b/src/Controller/TokenController.php
@@ -101,7 +101,7 @@ class TokenController extends BaseApiController
         }
 
         $tokens = $mapper->getTokenByIdAndUser(
-            $this->getItemId($request),
+            $this->getItemId($request, 'Token not found'),
             $request->user_id
         );
 
@@ -121,7 +121,7 @@ class TokenController extends BaseApiController
         }
 
         $token = $tokenMapper->getRevokableTokenByIdAndUser(
-            $this->getItemId($request),
+            $this->getItemId($request, 'Token not found'),
             $request->user_id
         );
 
@@ -130,7 +130,7 @@ class TokenController extends BaseApiController
         }
 
         try {
-            $tokenMapper->deleteToken($this->getItemId($request));
+            $tokenMapper->deleteToken($this->getItemId($request, 'Token not found'));
         } catch (Exception $e) {
             throw new Exception($e->getMessage(), Http::INTERNAL_SERVER_ERROR, $e);
         }

--- a/src/Controller/TracksController.php
+++ b/src/Controller/TracksController.php
@@ -13,7 +13,7 @@ class TracksController extends BaseApiController
 {
     public function getAction(Request $request, PDO $db): array
     {
-        $track_id = $this->getItemId($request);
+        $track_id = $this->getItemId($request, 'Track not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -40,7 +40,7 @@ class TracksController extends BaseApiController
             throw new Exception("You must be logged in to edit this track", Http::UNAUTHORIZED);
         }
 
-        $track_id = $this->getItemId($request);
+        $track_id = $this->getItemId($request, 'Track not found');
 
         $track_mapper = new TrackMapper($db, $request);
         $tracks       = $track_mapper->getTrackById($track_id, true);
@@ -100,7 +100,7 @@ class TracksController extends BaseApiController
             throw new Exception("You must be logged in to delete this track", Http::UNAUTHORIZED);
         }
 
-        $track_id = $this->getItemId($request);
+        $track_id = $this->getItemId($request, 'Track not found');
 
         $track_mapper = new TrackMapper($db, $request);
         $tracks       = $track_mapper->getTrackById($track_id, true);

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -28,7 +28,7 @@ class UsersController extends BaseApiController
 
     public function getAction(Request $request, PDO $db): array|bool
     {
-        $userId = $this->getItemId($request);
+        $userId = $this->getItemId($request, 'User not found');
 
         // verbosity
         $verbose = $this->getVerbosity($request);
@@ -259,7 +259,7 @@ class UsersController extends BaseApiController
             throw new Exception("You must be logged in to change a user account", Http::UNAUTHORIZED);
         }
 
-        $userId = $this->getItemId($request);
+        $userId = $this->getItemId($request, 'User not found');
 
         $userMapper = $this->getUserMapper($db, $request);
 
@@ -446,7 +446,7 @@ class UsersController extends BaseApiController
         }
 
         $this->initializeTalkCommentMapper($db, $request);
-        $this->talkCommentMapper->deleteCommentsForUser($this->getItemId($request));
+        $this->talkCommentMapper->deleteCommentsForUser($this->getItemId($request, 'User not found'));
 
         $view = $request->getView();
         $view->setHeader('Content-Length', '0');
@@ -467,7 +467,7 @@ class UsersController extends BaseApiController
             throw new Exception("You do not have permission to do that", Http::FORBIDDEN);
         }
 
-        if (!$userMapper->delete($this->getItemId($request))) {
+        if (!$userMapper->delete($this->getItemId($request, 'User not found'))) {
             throw new Exception("There was a problem trying to delete the user", Http::BAD_REQUEST);
         }
 
@@ -496,7 +496,7 @@ class UsersController extends BaseApiController
             throw new Exception("You must be an admin to change a user's trusted state", Http::FORBIDDEN);
         }
 
-        $userId = $this->getItemId($request);
+        $userId = $this->getItemId($request, 'User not found');
 
         if (!is_bool($trustedStatus = $request->getParameter("trusted", null))) {
             throw new Exception("You must provide a trusted state", Http::BAD_REQUEST);

--- a/tests/Controller/EventHostsControllerTest.php
+++ b/tests/Controller/EventHostsControllerTest.php
@@ -61,7 +61,7 @@ final class EventHostsControllerTest extends TestCase
         $controller->setEventMapper($em);
 
         $request               = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $request->url_elements = [3 => 'foo'];
+        $request->url_elements = [3 => 1];
         $request->user_id      = 2;
 
         $db = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
@@ -76,8 +76,8 @@ final class EventHostsControllerTest extends TestCase
         $this->expectExceptionCode(Http::FORBIDDEN);
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $request->user_id = 1;
-        $request->url_elements = [5 => 1];
+        $request->user_id = 2;
+        $request->url_elements = [3 => 1, 5 => 2];
 
         $db = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
 
@@ -124,7 +124,7 @@ final class EventHostsControllerTest extends TestCase
         $controller->setEventMapper($em);
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $request->url_elements = [3 => 'foo'];
+        $request->url_elements = [3 => 1];
         $request->user_id = 2;
 
         $db = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
@@ -177,7 +177,7 @@ final class EventHostsControllerTest extends TestCase
         $controller->setUserMapper($um);
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $request->url_elements = [3 => 'foo'];
+        $request->url_elements = [3 => 1];
         $request->user_id = 2;
         $request->method('getStringParameter')->willReturn('myhostname');
 

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -101,6 +101,7 @@ final class TalksControllerDeleteTest extends TalkBase
             ->setConstructorArgs([[], $httpRequest ])
             ->getMock();
 
+        $request->url_elements = [3 => 1];
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
@@ -167,6 +168,7 @@ final class TalksControllerDeleteTest extends TalkBase
             ->setConstructorArgs([[], $httpRequest ])
             ->getMock();
 
+        $request->url_elements = [3 => 1];
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -292,6 +292,7 @@ final class UsersControllerTest extends TestCase
     public function testThatUserDataIsNotDoubleEscapedOnUserEdit(): void
     {
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request->url_elements = [3 => 1];
         $request->method('getAccessToken')->willReturn('foo');
         $request->method('getUserId')->willReturn(1);
         $request->method('getStringParameter')->withConsecutive(
@@ -330,7 +331,7 @@ final class UsersControllerTest extends TestCase
             'email' => 'mailstuff@example.com',
             'twitter_username' => 'twitter"\'stuff',
             'biography' => 'Bio"\'stuff',
-            'user_id' => false,
+            'user_id' => 1,
         ])->willReturn(true);
 
         $controller = new UsersController();
@@ -403,6 +404,7 @@ final class UsersControllerTest extends TestCase
         $this->expectExceptionCode(Http::BAD_REQUEST);
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request->url_elements = [3 => 2];
         $request->method('getUserId')->willReturn(2);
         $request->method('getParameter')
             ->with("trusted")
@@ -437,6 +439,7 @@ final class UsersControllerTest extends TestCase
         $this->expectExceptionCode(Http::INTERNAL_SERVER_ERROR);
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request->url_elements = [3 => 2];
         $request->method('getUserId')->willReturn(2);
         $request->method('getParameter')
             ->with("trusted")
@@ -472,6 +475,7 @@ final class UsersControllerTest extends TestCase
     public function testSetTrustedWithSuccessCreatesView(): void
     {
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request->url_elements = [3 => 2];
         $request->method('getUserId')->willReturn(2);
         $request->method('getParameter')
             ->with("trusted")


### PR DESCRIPTION
I think this makes sense since otherwise each Controller would have to explicitly check the return type again and throw the same exception (with a slightly different message most likely). This brings down PHPStan errors to 116 with the downside that 404 exceptions are a bit more generic now.