### PR TITLE
Pass only ints around for pagination

### DIFF
--- a/src/Controller/BaseApiController.php
+++ b/src/Controller/BaseApiController.php
@@ -36,9 +36,9 @@ abstract class BaseApiController
         return true;
     }
 
-    public function getStart(Request $request): ?int
+    public function getStart(Request $request): int
     {
-        return $request->paginationParameters['start'];
+        return $request->paginationParameters['start'] ?? 0;
     }
 
     public function getResultsPerPage(Request $request): int

--- a/src/Model/ApiMapper.php
+++ b/src/Model/ApiMapper.php
@@ -84,19 +84,19 @@ class ApiMapper
     }
 
     /**
-     * @param ?int $resultsperpage
-     * @param ?int $start
+     * @param int $resultsperpage
+     * @param int $start
      *
      * @return string
      */
-    protected function buildLimit(int|string|null $resultsperpage, int|string|null $start): string
+    protected function buildLimit(int $resultsperpage, int $start): string
     {
         if ($resultsperpage == 0) {
             // special case, no limits
             return '';
         }
 
-        return ' LIMIT ' . (int) $start . ',' . (int) $resultsperpage;
+        return ' LIMIT ' . $start . ',' . $resultsperpage;
     }
 
     /**

--- a/src/Model/ClientMapper.php
+++ b/src/Model/ClientMapper.php
@@ -39,11 +39,11 @@ class ClientMapper extends ApiMapper
      *
      * @param int $user_id        The user to fetch clients for
      * @param int $resultsperpage How many results to return on each page
-     * @param int|null $start          Which result to start with
+     * @param int $start          Which result to start with
      *
      * @return ClientModelCollection
      */
-    public function getClientsForUser(int $user_id, int $resultsperpage, ?int $start): ClientModelCollection
+    public function getClientsForUser(int $user_id, int $resultsperpage, int $start): ClientModelCollection
     {
         $sql = 'SELECT * FROM oauth_consumers WHERE user_id = :user_id ';
         $sql .= $this->buildLimit($resultsperpage, $start);

--- a/src/Model/EventHostMapper.php
+++ b/src/Model/EventHostMapper.php
@@ -27,7 +27,7 @@ class EventHostMapper extends ApiMapper
      *
      * @return false|array
      */
-    public function getHostsByEventId(int $event_id, int $resultsperpage, ?int $start, $verbose = false)
+    public function getHostsByEventId(int $event_id, int $resultsperpage, int $start, $verbose = false)
     {
         $sql = $this->getHostSql();
         $sql .= ' order by host_name ';

--- a/src/Model/EventMapper.php
+++ b/src/Model/EventMapper.php
@@ -129,12 +129,12 @@ class EventMapper extends ApiMapper
      * Internal function called by other event-fetching code, with changeable SQL
      *
      * @param int      $resultsperpage how many records to return
-     * @param int|null $start          offset to start returning records from
+     * @param int      $start          offset to start returning records from
      * @param array    $params         filters and other parameters to limit/order the collection
      *
      * @return false|array the raw database results
      */
-    protected function getEvents(int $resultsperpage, ?int $start, array $params = []): array|false
+    protected function getEvents(int $resultsperpage, int $start, array $params = []): array|false
     {
         $data  = [];
         $order = " order by ";

--- a/src/Model/TalkCommentMapper.php
+++ b/src/Model/TalkCommentMapper.php
@@ -37,12 +37,12 @@ class TalkCommentMapper extends ApiMapper
     /**
      * @param int  $talk_id
      * @param int  $resultsperpage
-     * @param ?int $start
+     * @param int  $start
      * @param bool $verbose
      *
      * @return false|array
      */
-    public function getCommentsByTalkId(int $talk_id, int $resultsperpage, ?int $start, bool $verbose = false): array|false
+    public function getCommentsByTalkId(int $talk_id, int $resultsperpage, int $start, bool $verbose = false): array|false
     {
         $sql = $this->getBasicSQL();
         $sql .= 'and talk_id = :talk_id';

--- a/src/Model/TalkMapper.php
+++ b/src/Model/TalkMapper.php
@@ -135,12 +135,12 @@ class TalkMapper extends ApiMapper
      * Search talks by title
      *
      * @param string $keyword
-     * @param ?int    $resultsperpage
-     * @param ?int    $start
+     * @param int    $resultsperpage
+     * @param int    $start
      *
      * @return TalkModelCollection|bool Result collection or false on failure
      */
-    public function getTalksByTitleSearch(string $keyword, ?int $resultsperpage, ?int $start): bool|TalkModelCollection
+    public function getTalksByTitleSearch(string $keyword, int $resultsperpage, int $start): bool|TalkModelCollection
     {
         $sql = $this->getBasicSQL();
         $sql .= ' and LOWER(t.talk_title) like :title';
@@ -320,12 +320,12 @@ class TalkMapper extends ApiMapper
     /**
      * @param int $user_id
      * @param int $resultsperpage
-     * @param int|string|null $start
+     * @param int $start
      * @param bool $verbose
      *
      * @return false|TalkModelCollection
      */
-    public function getTalksBySpeaker(int $user_id, int $resultsperpage, int|string|null $start, bool $verbose = false): false|TalkModelCollection
+    public function getTalksBySpeaker(int $user_id, int $resultsperpage, int $start, bool $verbose = false): false|TalkModelCollection
     {
         // based on getBasicSQL() but needs the speaker table joins
         $sql = 'select t.*, l.lang_name, e.event_tz_place, e.event_tz_cont, '


### PR DESCRIPTION
gets rid of another 10 PHPStan errors


Alternatively if null should stay in the base controller, it could just be coalesced to 0 on use I guess?