### PR TITLE
Make PHPStan aware that BaseTalkController::checkLoggedIn() narrows the user_id of the given Request

### DIFF
--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -31,6 +31,10 @@ class BaseTalkController extends BaseApiController
 
     private UserMapper $user_mapper;
 
+    /**
+     * @phpstan-assert !null $request->user_id
+     * @phpstan-assert !null $request->getUserId()
+     */
     protected function checkLoggedIn(Request $request): void
     {
         $failMessages = [


### PR DESCRIPTION
Down to 29 errors because of this magic gem.

I didn't have time to check other places, but using something like this is a clean way to avoid having to add null checks everywhere user_id is used.

In case you wonder, this is mostly documented at https://phpstan.org/writing-php-code/narrowing-types#custom-type-checking-functions-and-methods